### PR TITLE
[ADD] Add fields to model templates

### DIFF
--- a/bobtemplates/odoo/hooks.py
+++ b/bobtemplates/odoo/hooks.py
@@ -215,8 +215,6 @@ def _insert_manifest_item(configurator, key, item):
     """ Insert an item in the list of an existing manifest key """
     with _open_manifest(configurator) as f:
         manifest = f.read()
-    if item in ast.literal_eval(manifest).get(key, []):
-        return
     pattern = """(["']{}["']:\\s*\\[)""".format(key)
     repl = """\\1\n        '{}',""".format(item)
     manifest = re.sub(pattern, repl, manifest, re.MULTILINE)

--- a/bobtemplates/odoo/hooks.py
+++ b/bobtemplates/odoo/hooks.py
@@ -10,6 +10,157 @@ from mrbob.bobexceptions import ValidationError
 from mrbob.hooks import show_message
 from pkg_resources import parse_version
 
+ODOO_FIELDS = [
+        'char',
+        'int', 'integer',
+        'date',
+        'datetime',
+        'text',
+        'selection',
+        'm2o', 'many2one',
+        'm2m', 'many2many',
+        'o2m', 'one2many',
+        'bool', 'boolean',
+        'bin', 'binary',
+        'float',
+]
+
+def _fields_to_dict(fields):
+    _fields = fields and fields.split(' ') or []
+    res = {}
+    for f in _fields:
+        if f:
+            attrs = f.split(':')
+            field_name = attrs[0]
+            field_string = _dotted_to_camelwords(field_name)
+            for string in attrs :
+                if string.strip() :
+                    string = string.strip()
+                    if string[0].isalpha()  and string[0] == string.capitalize()[0]:
+                        field_string = string
+            related_field = [x for x in attrs[1:] if '_' in x]
+            related_field = related_field and related_field[0] or ''
+            model = default = False
+            groups = ''
+            selection = []
+            field_type = list(set(ODOO_FIELDS).intersection(set(attrs)))
+            field_type = field_type and field_type[0] or False
+            if field_type:
+                attrs.remove(field_type)
+            if field_type == 'o2m' : field_type = 'one2many'
+            if field_type == 'm2m' : field_type = 'many2many'
+            if field_type == 'm2o' : field_type = 'many2one'
+            if field_type == 'bool' : field_type = 'boolean'
+            if field_type == 'bin' : field_type = 'binary'
+            if field_type == 'int' : field_type = 'integer'
+            if not field_type:
+                if field_name == 'sequence' :
+                    field_type = 'integer'
+                elif field_name == 'company_id' :
+                    field_type = 'many2one'
+                    model='res.company'
+                elif field_name == 'currency_id' :
+                    field_type = 'many2one'
+                    model='res.currency'
+                elif field_name == 'journal_id' :
+                    field_type = 'many2one'
+                    model='account.journal'
+                elif field_name == 'account_id' :
+                    field_type = 'many2one'
+                    model='account.account'
+                elif field_name == 'product_id' :
+                    field_type = 'many2one'
+                    model='product.product'
+                elif field_name == 'company_id' :
+                    field_type = 'many2one'
+                    model='res.company'
+                elif field_name == 'partner_id' :
+                    field_type = 'many2one'
+                    model='res.partner'
+                elif field_name == 'user_id' :
+                    field_type = 'many2one'
+                    model='res.users'
+                elif field_name == 'state' :
+                    field_type = 'selection'
+                    attrs.append('readonly')
+                elif field_name.endswith('s_id'):
+                    field_type = 'many2many'
+                elif field_name.endswith('_id'):
+                    field_type = 'many2one'
+                elif field_name.endswith('_ids'):
+                    field_type = 'one2many'
+                elif 'amount' in field_name:
+                    field_type = 'float'
+                elif 'date' in field_name:
+                    field_type = 'date'
+                elif 'count' in field_name:
+                    field_type = 'integer'
+                elif 'active' in field_name:
+                    field_type = 'integer'
+                    default = True
+            args = []
+            extras = []
+            if 'readonly' in attrs or 'ro' in attrs:
+                args.append(('readonly' , True),)
+            if 'required' in attrs :
+                args.append(('required' ,True),)
+            if 'store' in attrs :
+                args.append(('store' ,True),)
+            if 'nocopy' in attrs :
+                args.append(('copy' ,False),)
+            if 'translate' in attrs :
+                args.append(('translate' ,True),)
+            if 'nolist' in attrs or 'notree' in attrs:
+                extras.append('notree')
+            if 'noform' in attrs:
+                extras.append('noform')
+            if 'search' in attrs:
+                extras.append('search')
+            if 'compute' in attrs:
+                extras.append('compute')
+            if 'inverse' in attrs:
+                extras.append('inverse')
+                extras.append('compute')
+                store_exists = False
+                for i, arg in enumerate(args):
+                    if arg[0] == 'store':
+                        args[i] = ('store' ,False)
+                        store_exists = True
+                        break
+                if not store_exists :
+                    args.append(('store' ,False),)
+            for attr in attrs:
+                if ',' in attr :
+                    selection = attr.split(',')
+                    if selection:
+                        default = selection[0]
+                if '.' in attr :
+                    model = attr
+            if not field_type:
+                if model and '.' in model:
+                    field_type = 'many2one'
+                else:
+                    field_type = 'char'
+            if model == 'res.company' and 'many' in field_type:
+                groups='base.group_multi_company'
+            if model == 'res.currency' and 'many' in field_type:
+                groups='base.group_multi_currency'
+            if default:
+                if unicode(default) in ['now','today']:
+                    if field_type == 'date':
+                        default='lambda self: fields.Date.today()'
+                    if field_type == 'datetime':
+                        default='lambda self: fields.Datetime.now()'
+                if unicode(default) in ['me','user']:
+                    if field_type == 'many2one' or field_type == 'many2many':
+                        default='lambda self: self.env.user'
+                if unicode(default) in ['company']:
+                    if field_type == 'many2one':
+                        default='lambda self: self.env.user.company_id'
+                if field_type == 'selection':
+                    default = "'%s'" % default
+            res[field_name] = (field_string, field_type, args, extras, model, [(x, x.capitalize()) for x in selection], default, related_field, groups)
+    return res
 
 def _dotted_to_camelcased(dotted):
     return ''.join([s.capitalize() for s in dotted.split('.')])
@@ -17,6 +168,9 @@ def _dotted_to_camelcased(dotted):
 
 def _dotted_to_underscored(dotted):
     return dotted.replace('.', '_')
+
+def _underscored_to_dotted(dotted):
+    return dotted.replace('_', '.')
 
 
 def _dotted_to_camelwords(dotted):
@@ -61,6 +215,8 @@ def _insert_manifest_item(configurator, key, item):
     """ Insert an item in the list of an existing manifest key """
     with _open_manifest(configurator) as f:
         manifest = f.read()
+    if item in ast.literal_eval(manifest).get(key, []):
+        return
     pattern = """(["']{}["']:\\s*\\[)""".format(key)
     repl = """\\1\n        '{}',""".format(item)
     manifest = re.sub(pattern, repl, manifest, re.MULTILINE)
@@ -109,6 +265,8 @@ def pre_render_model(configurator):
         _dotted_to_underscored(variables['model.name_dotted'])
     variables['model.name_camelcased'] = \
         _dotted_to_camelcased(variables['model.name_dotted'])
+    variables['model.fields_mapped'] = \
+        _fields_to_dict(variables['model.fields'])
     variables['model.name_camelwords'] = \
         _dotted_to_camelwords(variables['model.name_dotted'])
     variables['addon.name'] = \

--- a/bobtemplates/odoo/model/.mrbob.ini
+++ b/bobtemplates/odoo/model/.mrbob.ini
@@ -10,9 +10,21 @@ model.inherit.question = Inherit
 model.inherit.default = y
 model.inherit.post_ask_question = mrbob.hooks:to_boolean
 
+model.view_ref.question = View ref
+model.view_ref.default =
+
+model.key.question = Key
+model.key.default =
+
+model.fields.question = Fields
+model.fields.default =
+
 model.view_form.question = Form view
 model.view_form.default = y
 model.view_form.post_ask_question = mrbob.hooks:to_boolean
+
+model.view_form_params.question = Form view params
+model.view_form_params.default = all
 
 model.view_search.question = Search view
 model.view_search.default = y
@@ -25,6 +37,9 @@ model.view_tree.post_ask_question = mrbob.hooks:to_boolean
 model.view_menu.question = Action and menu entry
 model.view_menu.default = y
 model.view_menu.post_ask_question = mrbob.hooks:to_boolean
+
+model.menu_parent.question = Parent Menu
+model.menu_parent.default =
 
 model.acl.question = ACL
 model.acl.default = y

--- a/bobtemplates/odoo/model/.mrbob.ini
+++ b/bobtemplates/odoo/model/.mrbob.ini
@@ -10,21 +10,12 @@ model.inherit.question = Inherit
 model.inherit.default = y
 model.inherit.post_ask_question = mrbob.hooks:to_boolean
 
-model.view_ref.question = View ref
-model.view_ref.default =
-
-model.key.question = Key
-model.key.default =
-
 model.fields.question = Fields
 model.fields.default =
 
 model.view_form.question = Form view
 model.view_form.default = y
 model.view_form.post_ask_question = mrbob.hooks:to_boolean
-
-model.view_form_params.question = Form view params
-model.view_form_params.default = all
 
 model.view_search.question = Search view
 model.view_search.default = y

--- a/bobtemplates/odoo/model/models/+model.name_underscored+.py.bob
+++ b/bobtemplates/odoo/model/models/+model.name_underscored+.py.bob
@@ -6,7 +6,7 @@ from {{% if odoo.version >= 10 %}}odoo{{% else %}}openerp{{% endif %}} import ap
 
 
 class {{{ model.name_camelcased }}}(models.Model):
-{{% if model.inherit == True %}}
+{{% if model.inherit %}}
     _inherit = '{{{ model.name_dotted }}}'
 {{% else %}}
     _name = '{{{ model.name_dotted }}}'

--- a/bobtemplates/odoo/model/models/+model.name_underscored+.py.bob
+++ b/bobtemplates/odoo/model/models/+model.name_underscored+.py.bob
@@ -6,12 +6,28 @@ from {{% if odoo.version >= 10 %}}odoo{{% else %}}openerp{{% endif %}} import ap
 
 
 class {{{ model.name_camelcased }}}(models.Model):
-
-{{% if model.inherit: %}}
+{{% if model.inherit == True %}}
     _inherit = '{{{ model.name_dotted }}}'
 {{% else %}}
     _name = '{{{ model.name_dotted }}}'
     _description = '{{{ model.name_camelwords }}}'  # TODO
 
-    name = fields.Char()
 {{% endif %}}
+{{% for field_name, (field_string, field_type, attrs, extras, model_name, selection, default, related_field, groups) in model.fields_mapped.iteritems() %}}
+{{% if 'compute' in extras %}}
+
+    @api.multi
+    @api.depends() #TODO
+    def _compute_{{{ field_name}}}(self):
+        for obj in self:
+            obj.{{{ field_name}}} = False #TODO
+{{% endif %}}
+{{% if 'inverse' in extras %}}
+
+    @api.one
+    def _inverse_{{{ field_name}}}(self):
+        if self.{{{ field_name}}}:
+            pass #TODO
+{{% endif %}}
+    {{{  field_name }}} = fields.{{{  field_type.capitalize() }}}({{%  if 'many' in field_type %}}'{{{ model_name }}}', {{% endif %}}{{%  if related_field and 'many' in field_type %}}'{{{ related_field }}}', {{% endif %}}{{% if field_type=='selection' and selection %}}{{{ selection }}}, {{% endif %}}string='{{{  field_string }}}', {{%  for x , y in attrs %}}{{{ x }}}={{{ y }}}, {{% endfor %}}{{%  if 'compute' in extras %}}compute='_compute_{{{ field_name}}}', {{% endif %}}{{%  if 'inverse' in extras %}}inverse='_inverse_{{{ field_name}}}', {{% endif %}}{{%  if default %}}default={{{ default }}}, {{% endif %}})
+{{% endfor %}}


### PR DESCRIPTION
Inspiring from Rails model's generator, 

If we type in the fields questions :

`user_id:Responsable:compute:store:inverse name:required date:date:readonly description:text:required:compute:store:readonly:invisible:nolist:notree user_res_id:required:res.users:::me, type sequence:noform state:drat,confirm,done,cancel date_creation:today,:date:search company_id:company, product_id:nocopy:translate`

We will get :

`

    @api.multi
    @api.depends() #TODO
    def _compute_user_id(self):
        for obj in self:
            obj.user_id = False #TODO

    @api.one
    def _inverse_user_id(self):
        if self.user_id:
            pass #TODO
    user_id = fields.Many2one('res.users', string='Responsable', store=False, compute='_compute_user_id', inverse='_inverse_user_id', )
    user_res_id = fields.Many2many('res.users', string='User_res_id', required=True, default=lambda self: self.env.user, )
    sequence = fields.Integer(string='Sequence', )

    @api.multi
    @api.depends() #TODO
    def _compute_description(self):
        for obj in self:
            obj.description = False #TODO
    description = fields.Text(string='Description', readonly=True, required=True, store=True, compute='_compute_description', )
    company_id = fields.Many2one('res.company', string='Company_id', default=lambda self: self.env.user.company_id, )
    state = fields.Selection([(u'drat', u'Drat'), (u'confirm', u'Confirm'), (u'done', u'Done'), (u'cancel', u'Cancel')], string='State', readonly=True, default='drat', )
    product_id = fields.Many2one('product.product', string='Product_id', copy=False, translate=True, )
    date = fields.Date(string='Date', readonly=True, )
    type = fields.Char(string='Type', )
    date_creation = fields.Date(string='Date_creation', default=lambda self: fields.Date.today(), )
    name = fields.Char(string='Name', required=True, )

`

If accepted, I will make a mini documentation on how to use it 🎱 