### PR TITLE
[FIX] Add local import: check if the string is exactly present in the __init__.py

### DIFF
--- a/bobtemplates/odoo/hooks.py
+++ b/bobtemplates/odoo/hooks.py
@@ -78,7 +78,7 @@ def _add_local_import(configurator, package, module):
         init = open(init_path).read()
     else:
         init = ''
-    if import_string not in init:
+    if import_string not in init.split():
         open(init_path, 'a').write(import_string + '\n')
 
 


### PR DESCRIPTION
When adding a first model like `model_name_extend` then adding `model_name`, `model_name` was not added because detected in the file.
In this commit, we check of the string is exactly present, not only included in another string.