### PR TITLE
[IMP] XML files: remove <data> tags in 9.0 and improve wizard buttons

### DIFF
--- a/bobtemplates/odoo/model/demo/+model.name_underscored+.xml.bob
+++ b/bobtemplates/odoo/model/demo/+model.name_underscored+.xml.bob
@@ -5,9 +5,6 @@
 {{% if odoo.version < 9 %}}
 <openerp>
 <data noupdate="1">
-{{% elif odoo.version == 9 %}}
-<odoo>
-<data noupdate="1">
 {{% else %}}
 <odoo noupdate="1">
 {{% endif %}}
@@ -18,10 +15,8 @@
     </record>
     -->
 
-{{% if odoo.version < 10 %}}
-</data>
-{{% endif %}}
 {{% if odoo.version < 9 %}}
+</data>
 </openerp>
 {{% else %}}
 </odoo>

--- a/bobtemplates/odoo/model/security/+model.name_underscored+.xml.bob
+++ b/bobtemplates/odoo/model/security/+model.name_underscored+.xml.bob
@@ -4,10 +4,10 @@
 
 {{% if odoo.version < 9 %}}
 <openerp>
+<data>
 {{% else %}}
 <odoo>
 {{% endif %}}
-<data>
 
     <record model="ir.model.access" id="{{{ model.name_underscored }}}_access_name"> <!-- TODO acl id -->
         <field name="name">{{{ model.name_dotted }}} access name</field> <!-- TODO acl name -->
@@ -20,8 +20,8 @@
         <field name="perm_unlink" eval="0"/>
     </record>
 
-</data>
 {{% if odoo.version < 9 %}}
+</data>
 </openerp>
 {{% else %}}
 </odoo>

--- a/bobtemplates/odoo/model/views/+model.name_underscored+.xml.bob
+++ b/bobtemplates/odoo/model/views/+model.name_underscored+.xml.bob
@@ -4,11 +4,9 @@
 
 {{% if odoo.version < 9 %}}
 <openerp>
+<data>
 {{% else %}}
 <odoo>
-{{% endif %}}
-{{% if odoo.version < 10 %}}
-<data>
 {{% endif %}}
 
 {{% if model.view_form %}}
@@ -95,10 +93,8 @@
     </record>
 
 {{% endif %}}
-{{% if odoo.version < 10 %}}
-</data>
-{{% endif %}}
 {{% if odoo.version < 9 %}}
+</data>
 </openerp>
 {{% else %}}
 </odoo>

--- a/bobtemplates/odoo/wizard/wizards/+wizard.name_underscored+.xml.bob
+++ b/bobtemplates/odoo/wizard/wizards/+wizard.name_underscored+.xml.bob
@@ -24,14 +24,24 @@
                     <field name="name"/>
                 </group>
                 <footer>
-                    <button name='doit'
-                        string='OK'
-                        class='btn-primary oe_highlight'
-                        type='object'/>
+                    <button name="doit"
+                            string="OK"
+                            {{% if odoo.version < 9 %}}
+                            class="oe_highlight"
+                            {{% else %}}
+                            class="btn-primary"
+                            {{% endif %}}
+                            type="object"/>
+                    {{% if odoo.version < 9 %}}
                     or
-                    <button string='Cancel'
-                        class='btn-default oe_link'
-                        special='cancel'/>
+                    {{% endif %}}
+                    <button string="Cancel"
+                            {{% if odoo.version < 9 %}}
+                            class="oe_link"
+                            {{% else %}}
+                            class="btn-default"
+                            {{% endif %}}
+                            special="cancel"/>
                 </footer>
             </form>
 {{% else %}}

--- a/bobtemplates/odoo/wizard/wizards/+wizard.name_underscored+.xml.bob
+++ b/bobtemplates/odoo/wizard/wizards/+wizard.name_underscored+.xml.bob
@@ -4,11 +4,9 @@
 
 {{% if odoo.version < 9 %}}
 <openerp>
+<data>
 {{% else %}}
 <odoo>
-{{% endif %}}
-{{% if odoo.version < 10 %}}
-<data>
 {{% endif %}}
 
 {{% if wizard.view_form %}}
@@ -71,10 +69,8 @@
     </record>
 {{% endif %}}
 
-{{% if odoo.version < 10 %}}
-</data>
-{{% endif %}}
 {{% if odoo.version < 9 %}}
+</data>
 </openerp>
 {{% else %}}
 </odoo>


### PR DESCRIPTION
- [x] `<data>` no longer required from version 9.0
- [x] `<noupdate>` key can be written in the `<odoo>` tag from version 9.0
- [x] Global improvement of buttons in the wizard form view: 
    - More specific style for versions before/after 8.0
    - Replace simple quotes by double quotes
    - Align button keys
    - Display the 'or' string only when version is <= 8.0