### PR TITLE
[FIX] Wizard Form View: indentation

### DIFF
--- a/bobtemplates/odoo/wizard/wizards/+wizard.name_underscored+.xml.bob
+++ b/bobtemplates/odoo/wizard/wizards/+wizard.name_underscored+.xml.bob
@@ -26,21 +26,21 @@
                 <footer>
                     <button name="doit"
                             string="OK"
-                            {{% if odoo.version < 9 %}}
+{{% if odoo.version < 9 %}}
                             class="oe_highlight"
-                            {{% else %}}
+{{% else %}}
                             class="btn-primary"
-                            {{% endif %}}
+{{% endif %}}
                             type="object"/>
-                    {{% if odoo.version < 9 %}}
+{{% if odoo.version < 9 %}}
                     or
-                    {{% endif %}}
+{{% endif %}}
                     <button string="Cancel"
-                            {{% if odoo.version < 9 %}}
+{{% if odoo.version < 9 %}}
                             class="oe_link"
-                            {{% else %}}
+{{% else %}}
                             class="btn-default"
-                            {{% endif %}}
+{{% endif %}}
                             special="cancel"/>
                 </footer>
             </form>
@@ -63,10 +63,10 @@
 
 {{% if wizard.action_multi %}}
     <record model="ir.values" id="{{{ wizard.name_underscored }}}_act_multi">
-        <field name="name">{{{ wizard.name_camelwords }}}</field><!-- TODO -->
+        <field name="name">{{{ wizard.name_camelwords }}}</field> <!-- TODO -->
         <field name="key2">client_action_multi</field>
         <field name="value" eval="'ir.actions.act_window,' +str(ref('{{{ wizard.name_underscored }}}_act_window'))" />
-        <field name="model">source.model</field><!-- TODO -->
+        <field name="model">source.model</field> <!-- TODO -->
     </record>
 {{% endif %}}
 
@@ -78,7 +78,6 @@
         <field name="sequence" eval="16"/> <!-- TODO -->
     </record>
 {{% endif %}}
-
 {{% if odoo.version < 9 %}}
 </data>
 </openerp>


### PR DESCRIPTION
This PR fixes an indentation issue in a new wizard form view.

Before:
![bobtemplates_wizard_view_before](https://user-images.githubusercontent.com/16916103/35668535-277d12d0-0732-11e8-9316-b94891bb7bff.png)

Now:
![bobtemplates_wizard_view](https://user-images.githubusercontent.com/16916103/35668548-2cf65b86-0732-11e8-8c67-c0ab3aef98a9.png)
