### PR TITLE
[IMP] - remove view name

### DIFF
--- a/bobtemplates/odoo/model/views/+model.name_underscored+.xml.bob
+++ b/bobtemplates/odoo/model/views/+model.name_underscored+.xml.bob
@@ -11,7 +11,9 @@
 
 {{% if model.view_form %}}
     <record model="ir.ui.view" id="{{{ model.name_underscored }}}_form_view">
+{{% if odoo.version < 12 %}}
         <field name="name">{{{ model.name_dotted }}}.form (in {{{ addon.name }}})</field>
+{{% endif %}}
         <field name="model">{{{ model.name_dotted }}}</field>
 {{% if model.inherit %}}
         <field name="inherit_id" ref="TODO othermodule.form_view"/>
@@ -39,7 +41,9 @@
 
 {{% if model.view_search %}}
     <record model="ir.ui.view" id="{{{ model.name_underscored }}}_search_view">
+{{% if odoo.version < 12 %}}
         <field name="name">{{{ model.name_dotted }}}.search (in {{{ addon.name }}})</field>
+{{% endif %}}
         <field name="model">{{{ model.name_dotted }}}</field>
 {{% if model.inherit %}}
         <field name="inherit_id" ref="TODO othermodule.search_view"/>
@@ -58,7 +62,9 @@
 
 {{% if model.view_tree %}}
     <record model="ir.ui.view" id="{{{ model.name_underscored }}}_tree_view">
+{{% if odoo.version < 12 %}}
         <field name="name">{{{ model.name_dotted }}}.tree (in {{{ addon.name }}})</field>
+{{% endif %}}
         <field name="model">{{{ model.name_dotted }}}</field>
 {{% if model.inherit %}}
         <field name="inherit_id" ref="TODO othermodule.tree_view"/>

--- a/bobtemplates/odoo/wizard/wizards/+wizard.name_underscored+.xml.bob
+++ b/bobtemplates/odoo/wizard/wizards/+wizard.name_underscored+.xml.bob
@@ -11,7 +11,9 @@
 
 {{% if wizard.view_form %}}
     <record model="ir.ui.view" id="{{{ wizard.name_underscored }}}_form_view">
+{{% if odoo.version < 12 %}}
         <field name="name">{{{ wizard.name_dotted }}}.form (in {{{ addon.name }}})</field>
+{{% endif %}}
         <field name="model">{{{ wizard.name_dotted }}}</field>
 {{% if wizard.inherit %}}
         <field name="inherit_id" ref="TODO othermodule.wizard"/>


### PR DESCRIPTION
Since version 12, Odoo automatically generates the name of a view if it is not specified in the XML definition. Additionally, the external ID is displayed, so we can determine in which module this view is defined.

![image](https://github.com/acsone/bobtemplates.odoo/assets/12665409/238229ad-aba3-468d-a049-1e2b3bbca8c2)
