### PR TITLE
Fix mrbob executable not being provided by bobtemplates.odoo

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,4 +29,9 @@ setup(
     include_package_data=True,
     setup_requires=["setuptools_scm"],
     python_requires=">=3.7",
+    entry_points={
+        "console_scripts": [
+            "mrbob = mrbob.cli:main",
+        ],
+    },
 )


### PR DESCRIPTION
Add `console_scripts` entry point to `setup.py` to expose the `mrbob` command directly from `bobtemplates.odoo` package. This resolves the warning when using `uvx --from bobtemplates.odoo mrbob` where `uv` complains that `mrbob` is not provided by `bobtemplates-odoo` but is available via the dependency `mr-bob`.