### PR TITLE
[IMP] add maintainers to manifest

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -89,6 +89,7 @@ Contributors:
   * Olivier Laurent (`ACSONE <http://acsone.eu/>`_)
   * Mohamed Cherkaoui
   * Thomas Binsfeld (`ACSONE <http://acsone.eu/>`_)
+  * Souheil Bejaoui (`ACSONE <http://acsone.eu/>`_)
 
 Maintainer
 ----------

--- a/bobtemplates/odoo/addon/+addon.name+/__openerp__.py.bob
+++ b/bobtemplates/odoo/addon/+addon.name+/__openerp__.py.bob
@@ -11,6 +11,13 @@
     'author': '{{{ copyright.name }}}{{% if addon.oca %}},Odoo Community Association (OCA){{% endif %}}',
 {{% if copyright.website %}}
     'website': '{{{ copyright.website }}}',
+{{% if addon.oca and addon.maintainers %}}
+    'maintainers': [
+{{% for maintainer in addon.maintainers.split(',') if maintainer.strip() %}}
+        '{{{ maintainer.strip() }}}'{{% if not loop.last %}},{{% endif %}}
+{{% endfor %}}
+    ],
+{{% endif %}}
 {{% endif %}}
     'depends': [
     ],

--- a/bobtemplates/odoo/addon/.mrbob.ini
+++ b/bobtemplates/odoo/addon/.mrbob.ini
@@ -24,6 +24,9 @@ copyright.year.required = True
 
 copyright.website.question = Website
 
+addon.maintainers.question = Maintainers (comma-separated GitHub logins, leave empty if none)
+addon.maintainers.default =
+
 [template]
 pre_render = bobtemplates.odoo.hooks:pre_render_addon
 post_render = bobtemplates.odoo.hooks:post_render_addon

--- a/tests/test_odoo_addon_answers.ini
+++ b/tests/test_odoo_addon_answers.ini
@@ -7,3 +7,4 @@ addon.version = 10.0.1.0.0
 copyright.name = Some fool
 copyright.website = http://foobar.org
 copyright.year = 1984
+addon.maintainers = user1,user2

--- a/tests/test_odoo_addon_no_readme_answers.ini
+++ b/tests/test_odoo_addon_no_readme_answers.ini
@@ -7,3 +7,4 @@ addon.version = 10.0.1.0.0
 copyright.name = Some fool
 copyright.website = http://foobar.org
 copyright.year = 1984
+addon.maintainers = user1,user2

--- a/tests/test_odoo_addon_oca_answers.ini
+++ b/tests/test_odoo_addon_oca_answers.ini
@@ -7,3 +7,4 @@ addon.version = 10.0.1.0.0
 copyright.name = Some fool
 copyright.website = http://foobar.org
 copyright.year = 1984
+addon.maintainers = user1,user2

--- a/tests/test_odoo_addon_oca_no_readme_answers.ini
+++ b/tests/test_odoo_addon_oca_no_readme_answers.ini
@@ -7,3 +7,4 @@ addon.version = 10.0.1.0.0
 copyright.name = Some fool
 copyright.website = http://foobar.org
 copyright.year = 1984
+addon.maintainers = user1,user2

--- a/tests/test_odoo_readme_answers.ini
+++ b/tests/test_odoo_readme_answers.ini
@@ -2,3 +2,4 @@
 addon.name = addon_foo
 addon.oca = n
 addon.summary = Summary of addon foo purpose
+addon.maintainers = user1,user2

--- a/tests/test_odoo_readme_oca_answers.ini
+++ b/tests/test_odoo_readme_oca_answers.ini
@@ -2,3 +2,4 @@
 addon.name = addon_foo
 addon.oca = y
 addon.summary = Summary of addon foo purpose
+addon.maintainers = user1,user2

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -1,6 +1,7 @@
 # Copyright © 2016 ACSONE SA/NV
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
+import ast
 import os
 import shutil
 import tempfile
@@ -72,6 +73,9 @@ class OdooTemplatesTest(BaseTemplateTest):
                 self.addon + "/static/description/icon.png",
             },
         )
+        manifest_file = result.files_created[self.addon + "/__manifest__.py"]
+        manifest = ast.literal_eval(manifest_file.bytes)
+        self.assertEqual(manifest["maintainers"], ["user1", "user2"])
 
     def test_odoo_addon_acsone(self):
         result = self._create_addon()


### PR DESCRIPTION
ask for the maintainers list in the manifest
this helps devs remember to declare themselves as maintainers of the modules they create