### PR TITLE
[IMP] Add missing security and _description to wizard

### DIFF
--- a/bobtemplates/odoo/hooks.py
+++ b/bobtemplates/odoo/hooks.py
@@ -312,5 +312,8 @@ def post_render_wizard(configurator):
         _insert_manifest_item(configurator, "data", view_path)
     else:
         _delete_file(configurator, view_path)
+    # ACL
+    acl_path = "security/{}.xml".format(variables["wizard.name_underscored"])
+    _insert_manifest_item(configurator, "data", acl_path)
     # show message if any
     show_message(configurator)

--- a/bobtemplates/odoo/wizard/security/+wizard.name_underscored+.xml.bob
+++ b/bobtemplates/odoo/wizard/security/+wizard.name_underscored+.xml.bob
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright {{{ copyright.year }}} {{{ copyright.name }}}
+     License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). -->
+
+{{% if odoo.version < 9 %}}
+<openerp>
+<data>
+{{% else %}}
+<odoo>
+{{% endif %}}
+
+    <record model="ir.model.access" id="{{{ wizard.name_underscored }}}_access_name"> <!-- TODO acl id -->
+        <field name="name">{{{ wizard.name_dotted }}} access name</field> <!-- TODO acl name -->
+        <field name="model_id" ref="model_{{{ wizard.name_underscored }}}"/>
+        <!-- TODO review and adapt -->
+        <field name="group_id" ref="base.group_user"/>
+        <field name="perm_read" eval="1"/>
+        <field name="perm_create" eval="0"/>
+        <field name="perm_write" eval="0"/>
+        <field name="perm_unlink" eval="0"/>
+    </record>
+
+{{% if odoo.version < 9 %}}
+</data>
+</openerp>
+{{% else %}}
+</odoo>
+{{% endif %}}

--- a/bobtemplates/odoo/wizard/wizards/+wizard.name_underscored+.py.bob
+++ b/bobtemplates/odoo/wizard/wizards/+wizard.name_underscored+.py.bob
@@ -12,6 +12,7 @@ class {{{ wizard.name_camelcased }}}(models.TransientModel):
     _inherit = "{{{ wizard.name_dotted }}}"
 {{% else %}}
     _name = "{{{ wizard.name_dotted }}}"
+    _description = "{{{ wizard.name_camelwords }}}"
 
     name = fields.Char()
 

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -165,6 +165,8 @@ class OdooTemplatesTest(BaseTemplateTest):
         self.assertEqual(
             set(result.files_created.keys()),
             {
+                self.addon + "/security",
+                self.addon + "/security/foo_wizard.xml",
                 self.addon + "/wizards",
                 self.addon + "/wizards/foo_wizard.py",
                 self.addon + "/wizards/__init__.py",


### PR DESCRIPTION
`_description` and `ir.model.access` are required for wizards