### PR TITLE
[IMP] Use BaseCommon for tests

### DIFF
--- a/bobtemplates/odoo/hooks.py
+++ b/bobtemplates/odoo/hooks.py
@@ -254,6 +254,7 @@ def pre_render_test(configurator):
         variables["test.name_underscored"]
     )
     variables["test.is_class_method"] = variables["test.common_class"] in (
+        "BaseCommon",
         "SavepointCase",
         "SingleTransactionCase",
     )

--- a/bobtemplates/odoo/test/.mrbob.ini
+++ b/bobtemplates/odoo/test/.mrbob.ini
@@ -6,8 +6,8 @@ odoo.version.required = True
 test.name_underscored.question = Test file name (with underscores)
 test.name_underscored.required = True
 
-test.common_class.question = Test common class (TransactionCase|SingleTransactionCase|SavepointCase)
-test.common_class.default = TransactionCase
+test.common_class.question = Test common class (BaseCommon|TransactionCase|SingleTransactionCase|SavepointCase)
+test.common_class.default = BaseCommon
 test.common_class.required = True
 
 copyright.name.question = Copyright holder name


### PR DESCRIPTION
OCA Guidelines:
In Odoo 16+, use the BaseCommon test class for improved context with tracking disabled and other optimizations.