### PR TITLE
Improve imports

### DIFF
--- a/bobtemplates/odoo/model/models/+model.name_underscored+.py.bob
+++ b/bobtemplates/odoo/model/models/+model.name_underscored+.py.bob
@@ -3,7 +3,7 @@
 # Copyright {{{ copyright.year }}} {{{ copyright.name }}}
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
-from {{% if odoo.version >= 10 %}}odoo{{% else %}}openerp{{% endif %}} import {{% if odoo.version < 18 %}}_, {{% endif %}}api, fields, models
+from {{% if odoo.version >= 10 %}}odoo{{% else %}}openerp{{% endif %}} import {{% if odoo.version < 18 %}}_, {{% endif %}}api, exceptions, fields, models
 
 
 class {{{ model.name_camelcased }}}(models.Model):

--- a/bobtemplates/odoo/model/models/+model.name_underscored+.py.bob
+++ b/bobtemplates/odoo/model/models/+model.name_underscored+.py.bob
@@ -3,7 +3,7 @@
 # Copyright {{{ copyright.year }}} {{{ copyright.name }}}
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
-from {{% if odoo.version >= 10 %}}odoo{{% else %}}openerp{{% endif %}} import _, api, fields, models
+from {{% if odoo.version >= 10 %}}odoo{{% else %}}openerp{{% endif %}} import {{% if odoo.version < 18 %}}_, {{% endif %}}api, fields, models
 
 
 class {{{ model.name_camelcased }}}(models.Model):


### PR DESCRIPTION
- Do not import `_` from 18+ (since we should use `self.env._`)
- Import `exceptions` since it's often used (and if not, pre-commit removes superfluous imports)